### PR TITLE
feat: 설정 탭 신설·정비 + 음성 녹음 강화

### DIFF
--- a/PrayAnswer.xcodeproj/project.pbxproj
+++ b/PrayAnswer.xcodeproj/project.pbxproj
@@ -479,7 +479,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.13;
+				MARKETING_VERSION = 1.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.restart.PrayAnswer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -523,7 +523,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.13;
+				MARKETING_VERSION = 1.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.restart.PrayAnswer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/PrayAnswer/ContentView.swift
+++ b/PrayAnswer/ContentView.swift
@@ -95,7 +95,7 @@ struct ContentView: View {
             selectedTab = 2
 
         case "stats":
-            // prayanswer://stats → 통계 탭
+            // prayanswer://stats → 설정 탭
             selectedTab = 4
 
         default:
@@ -184,11 +184,11 @@ struct iPhoneContentView: View {
                 }
                 .tag(3)
 
-            // 통계 탭 (4)
-            StatisticsView()
+            // 설정 탭 (4)
+            SettingsView()
                 .tabItem {
-                    Image(systemName: "chart.bar.xaxis")
-                    Text(L.Tab.statistics)
+                    Image(systemName: "gearshape.fill")
+                    Text(L.Settings.tabTitle)
                 }
                 .tag(4)
         }
@@ -254,7 +254,7 @@ struct iPadContentView: View {
         case prayers = "prayers"
         case people = "people"
         case addPrayer = "addPrayer"
-        case statistics = "statistics"
+        case settings = "settings"
         case habit = "habit"
 
         var id: String { rawValue }
@@ -264,7 +264,7 @@ struct iPadContentView: View {
             case .prayers: return L.Tab.prayerList
             case .people: return L.Tab.people
             case .addPrayer: return L.Tab.addPrayer
-            case .statistics: return L.Tab.statistics
+            case .settings: return L.Settings.tabTitle
             case .habit: return L.Habit.navTitle
             }
         }
@@ -274,7 +274,7 @@ struct iPadContentView: View {
             case .prayers: return "list.bullet.rectangle.portrait"
             case .people: return "person.2"
             case .addPrayer: return "hands.clap"
-            case .statistics: return "chart.bar.xaxis"
+            case .settings: return "gearshape.fill"
             case .habit: return "clock.badge.checkmark"
             }
         }
@@ -377,8 +377,8 @@ struct iPadContentView: View {
         case .addPrayer:
             AddPrayerView(selectedTab: $dummyAddPrayerTab)
 
-        case .statistics:
-            StatisticsView()
+        case .settings:
+            SettingsView()
 
         case .habit:
             HabitView()

--- a/PrayAnswer/Utils/LocalizationKeys.swift
+++ b/PrayAnswer/Utils/LocalizationKeys.swift
@@ -619,6 +619,60 @@ enum L {
         static let noPlaceholder = NSLocalizedString("answer_note.no_placeholder", value: "결과를 기록해보세요 (선택 입력)", comment: "Placeholder for no storage answer note")
     }
 
+    // MARK: - Settings Tab
+    enum Settings {
+        static let tabTitle = NSLocalizedString("settings.tab_title", value: "설정", comment: "Settings tab title")
+        static let guideSection = NSLocalizedString("settings.guide_section", value: "사용법 가이드", comment: "How to use section title")
+        static let aiSection = NSLocalizedString("settings.ai_section", value: "AI · 음성 설정", comment: "AI and voice settings section")
+        static let aiToggle = NSLocalizedString("settings.ai_toggle", value: "AI 요약 사용", comment: "AI summarization toggle label")
+        static let aiToggleDesc = NSLocalizedString("settings.ai_toggle_desc", value: "음성 녹음 후 Apple Intelligence로 기도문을 자동 정리합니다 (iOS 18.1+, Apple Intelligence 필요)", comment: "AI toggle description")
+        static let bluetoothTip = NSLocalizedString("settings.bluetooth_tip", value: "에어팟·블루투스 마이크를 연결하면 더 선명하게 녹음됩니다", comment: "Bluetooth mic tip")
+        static let voiceChunkingTip = NSLocalizedString("settings.voice_chunking_tip", value: "긴 기도 나눔도 자동으로 이어 녹음됩니다 (1분 이상 지원)", comment: "Long recording tip")
+        static let statsSection = NSLocalizedString("settings.stats_section", value: "기도 통계", comment: "Statistics section")
+        static let statsButton = NSLocalizedString("settings.stats_button", value: "기도 통계 보기", comment: "View statistics button")
+        static let statsDesc = NSLocalizedString("settings.stats_desc", value: "응답률, 카테고리 분포, 월별 기도 추이를 확인하세요", comment: "Statistics description")
+        static let appSection = NSLocalizedString("settings.app_section", value: "앱 정보", comment: "App info section title")
+        static let version = NSLocalizedString("settings.version", value: "버전", comment: "Version label")
+        static let contact = NSLocalizedString("settings.contact", value: "문의하기", comment: "Contact button")
+        static let review = NSLocalizedString("settings.review", value: "앱 평가하기", comment: "Rate app button")
+        static let privacyPolicy = NSLocalizedString("settings.privacy_policy", value: "개인정보 처리방침", comment: "Privacy policy")
+    }
+
+    // MARK: - Feature Guide Cards
+    enum Guide {
+        static let addPrayerTitle = NSLocalizedString("guide.add_prayer_title", value: "기도제목 추가", comment: "")
+        static let addPrayerDesc = NSLocalizedString("guide.add_prayer_desc", value: "하단 '추가' 탭에서 기도제목·내용·카테고리·대상자를 입력하고 저장하세요.", comment: "")
+        static let storageTitle = NSLocalizedString("guide.storage_title", value: "보관소 관리", comment: "")
+        static let storageDesc = NSLocalizedString("guide.storage_desc", value: "Wait·Yes·No 세 보관소로 기도 상태를 추적하세요. 상세 화면에서 보관소를 이동할 수 있습니다.", comment: "")
+        static let peopleTitle = NSLocalizedString("guide.people_title", value: "여러 사람 기도", comment: "")
+        static let peopleDesc = NSLocalizedString("guide.people_desc", value: "'대상자' 탭에서 사람별 기도제목을 한눈에 관리하세요. 가족·친구·공동체별로 정리됩니다.", comment: "")
+        static let favoriteTitle = NSLocalizedString("guide.favorite_title", value: "즐겨찾기", comment: "")
+        static let favoriteDesc = NSLocalizedString("guide.favorite_desc", value: "자주 기도하는 제목에 ♥를 표시하면 위젯과 목록 상단에서 빠르게 접근할 수 있습니다.", comment: "")
+        static let habitTitle = NSLocalizedString("guide.habit_title", value: "기도 습관", comment: "")
+        static let habitDesc = NSLocalizedString("guide.habit_desc", value: "'습관' 탭에서 매일 기도 체크인을 기록하세요. 연속 기도일과 주간 달력으로 꾸준함을 확인할 수 있습니다.", comment: "")
+        static let widgetTitle = NSLocalizedString("guide.widget_title", value: "홈 화면 위젯", comment: "")
+        static let widgetDesc = NSLocalizedString("guide.widget_desc", value: "홈 화면 길게 누르기 → 위젯 추가 → PrayAnswer. 기도제목 확인과 빠른 추가가 잠금 화면에서도 가능합니다.", comment: "")
+        static let exchangeTitle = NSLocalizedString("guide.exchange_title", value: "기도 교환", comment: "")
+        static let exchangeDesc = NSLocalizedString("guide.exchange_desc", value: "기도제목을 상대방과 교환하세요. 앱이 있으면 딥링크로 바로 저장, 없으면 텍스트로 전달됩니다.", comment: "")
+        static let shareExtTitle = NSLocalizedString("guide.share_ext_title", value: "다른 앱에서 가져오기", comment: "")
+        static let shareExtDesc = NSLocalizedString("guide.share_ext_desc", value: "카카오톡·메모 등에서 텍스트를 선택 → 공유 → PrayAnswer를 탭하면 바로 기도제목으로 추가됩니다.", comment: "")
+        static let collectionTitle = NSLocalizedString("guide.collection_title", value: "컬렉션(폴더)", comment: "")
+        static let collectionDesc = NSLocalizedString("guide.collection_desc", value: "기도제목을 주제별 폴더로 묶어 정리하세요. 기도제목 추가·편집 화면에서 폴더를 지정할 수 있습니다.", comment: "")
+        static let answerNoteTitle = NSLocalizedString("guide.answer_note_title", value: "응답 기록", comment: "")
+        static let answerNoteDesc = NSLocalizedString("guide.answer_note_desc", value: "기도가 응답받으면 Yes로 이동할 때 어떻게 응답받았는지 메모를 남겨 하나님의 역사를 기록하세요.", comment: "")
+        static let voiceAITitle = NSLocalizedString("guide.voice_ai_title", value: "음성 AI 기록", comment: "")
+        static let voiceAIDesc = NSLocalizedString("guide.voice_ai_desc", value: "기도제목 추가·편집 화면의 🎤 버튼으로 말하면 Apple Intelligence가 기도문으로 자동 정리해 줍니다.", comment: "")
+    }
+
+    // MARK: - Voice Recording (enhanced)
+    enum VoiceEnhanced {
+        static let pause = NSLocalizedString("voice.pause", value: "일시정지", comment: "Pause recording")
+        static let resume = NSLocalizedString("voice.resume", value: "재개", comment: "Resume recording")
+        static let paused = NSLocalizedString("voice.paused", value: "일시정지됨", comment: "Recording paused state")
+        static let continuing = NSLocalizedString("voice.continuing", value: "계속 녹음 중...", comment: "Auto-chunking in progress")
+        static let timerFormat = NSLocalizedString("voice.timer_format", value: "%02d:%02d", comment: "MM:SS timer format")
+    }
+
     // MARK: - Siri / App Intents
     enum Siri {
         static let addPrayerTitle = NSLocalizedString("siri.add_prayer_title", value: "기도제목 추가", comment: "Siri add prayer intent title")

--- a/PrayAnswer/Utils/PrayerExchangePackage.swift
+++ b/PrayAnswer/Utils/PrayerExchangePackage.swift
@@ -56,8 +56,8 @@ enum PrayerExchangePackageError: LocalizedError {
 
 enum PrayerExchangePackager {
 
-    // App Store URL — 출시 후 실제 ID로 교체
-    static let appStoreURL = "https://apps.apple.com/kr/app/prayanswer/id6748534851"
+    // App Store URL (라이브 앱 ID, KR·US 스토어프론트 게시됨)
+    static let appStoreURL = "https://apps.apple.com/kr/app/id6748029078"
 
     private static let decoder: JSONDecoder = {
         let d = JSONDecoder()
@@ -136,9 +136,8 @@ enum PrayerExchangePackager {
 
         lines.append("")
         lines.append("─────────────────────")
-        lines.append("📲 PrayAnswer 앱으로 기도제목 받기:")
-        lines.append("• 앱이 있다면: 링크를 눌러 바로 저장")
-        lines.append("• 앱이 없다면: 링크에서 먼저 다운로드 후 저장")
+        lines.append("함께 기도해 주세요 🙏")
+        lines.append("PrayAnswer 앱에서 기도제목을 관리할 수 있어요:")
         lines.append(appStoreURL)
 
         return lines.joined(separator: "\n")

--- a/PrayAnswer/Utils/SpeechRecognitionManager.swift
+++ b/PrayAnswer/Utils/SpeechRecognitionManager.swift
@@ -1,28 +1,28 @@
 import Foundation
 import Speech
 import AVFoundation
+import Accelerate
 
 /// 음성 인식 관리자 - Speech Framework를 사용한 음성→텍스트 변환
+/// 개선 사항: 블루투스 마이크 지원, 1분 자동 청킹, 오디오 레벨 미터, 일시정지/재개
 @Observable
 final class SpeechRecognitionManager: NSObject {
     static let shared = SpeechRecognitionManager()
 
-    // MARK: - Published Properties
+    // MARK: - Observable Properties
 
-    /// 현재 인식된 텍스트
     var recognizedText: String = ""
-
-    /// 녹음 중 여부
     var isRecording: Bool = false
-
-    /// 에러 메시지
+    var isPaused: Bool = false
     var errorMessage: String?
-
-    /// 권한 상태
     var authorizationStatus: SFSpeechRecognizerAuthorizationStatus = .notDetermined
-
-    /// 마이크 권한 상태
     var microphonePermissionGranted: Bool = false
+
+    /// 실시간 오디오 입력 레벨 (0.0 ~ 1.0) — 파형 시각화용
+    var audioLevel: Float = 0.0
+
+    /// 녹음 경과 시간 (초)
+    var elapsedSeconds: Int = 0
 
     // MARK: - Private Properties
 
@@ -31,10 +31,22 @@ final class SpeechRecognitionManager: NSObject {
     private var recognitionTask: SFSpeechRecognitionTask?
     private let audioEngine = AVAudioEngine()
 
+    /// 청킹: 이전 청크에서 누적된 텍스트
+    private var accumulatedText: String = ""
+
+    /// 청킹 타이머 — 55초마다 새 recognitionRequest로 교체
+    private var chunkTimer: Timer?
+    private let chunkInterval: TimeInterval = 55
+
+    /// 녹음 경과 시간 타이머
+    private var elapsedTimer: Timer?
+
+    /// 일시정지 시점의 누적 텍스트 스냅샷
+    private var pauseSnapshot: String = ""
+
     // MARK: - Initialization
 
     private override init() {
-        // 한국어 음성 인식기 초기화
         self.speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: "ko-KR"))
         super.init()
         self.speechRecognizer?.delegate = self
@@ -42,7 +54,6 @@ final class SpeechRecognitionManager: NSObject {
 
     // MARK: - Permission Requests
 
-    /// 음성 인식 권한 요청
     func requestSpeechAuthorization(completion: @escaping (Bool) -> Void) {
         SFSpeechRecognizer.requestAuthorization { [weak self] status in
             DispatchQueue.main.async {
@@ -52,7 +63,6 @@ final class SpeechRecognitionManager: NSObject {
         }
     }
 
-    /// 마이크 권한 요청
     func requestMicrophonePermission(completion: @escaping (Bool) -> Void) {
         AVAudioApplication.requestRecordPermission { [weak self] granted in
             DispatchQueue.main.async {
@@ -62,99 +72,31 @@ final class SpeechRecognitionManager: NSObject {
         }
     }
 
-    /// 모든 권한 요청
     func requestAllPermissions(completion: @escaping (Bool) -> Void) {
         requestSpeechAuthorization { [weak self] speechGranted in
-            guard speechGranted else {
-                completion(false)
-                return
-            }
-
+            guard speechGranted else { completion(false); return }
             self?.requestMicrophonePermission { micGranted in
                 completion(micGranted)
             }
         }
     }
 
-    /// 권한 상태 확인
     func checkPermissions() -> Bool {
-        return authorizationStatus == .authorized && microphonePermissionGranted
+        authorizationStatus == .authorized && microphonePermissionGranted
     }
 
     // MARK: - Recording Control
 
-    /// 녹음 시작
     func startRecording() throws {
-        // 이전 작업 정리
-        if recognitionTask != nil {
-            recognitionTask?.cancel()
-            recognitionTask = nil
-        }
+        guard !isRecording else { return }
 
-        // 오디오 세션 설정
-        let audioSession = AVAudioSession.sharedInstance()
-        try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
-        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+        accumulatedText = ""
+        elapsedSeconds = 0
+        isPaused = false
 
-        // 인식 요청 생성
-        recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
-
-        guard let recognitionRequest = recognitionRequest else {
-            throw SpeechRecognitionError.requestCreationFailed
-        }
-
-        // 실시간 결과 반환 설정
-        recognitionRequest.shouldReportPartialResults = true
-
-        // 음성 인식기 확인
-        guard let speechRecognizer = speechRecognizer, speechRecognizer.isAvailable else {
-            throw SpeechRecognitionError.recognizerNotAvailable
-        }
-
-        // 인식 작업 시작
-        recognitionTask = speechRecognizer.recognitionTask(with: recognitionRequest) { [weak self] result, error in
-            guard let self = self else { return }
-
-            var isFinal = false
-
-            if let result = result {
-                DispatchQueue.main.async {
-                    self.recognizedText = result.bestTranscription.formattedString
-                }
-                isFinal = result.isFinal
-            }
-
-            // 에러 또는 최종 결과일 때 정리
-            if error != nil || isFinal {
-                // 오디오 엔진이 아직 실행 중이면 중지 (오디오 리소스는 백그라운드에서 처리 가능)
-                if self.audioEngine.isRunning {
-                    self.audioEngine.stop()
-                    self.audioEngine.inputNode.removeTap(onBus: 0)
-                }
-
-                try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
-
-                // @Observable 프로퍼티는 반드시 메인 스레드에서 수정
-                DispatchQueue.main.async {
-                    self.recognitionRequest = nil
-                    self.recognitionTask = nil
-                    self.isRecording = false
-                }
-            }
-        }
-
-        // 오디오 입력 노드 설정 (기존 탭이 있으면 먼저 제거 - 빠른 재시작 시 크래시 방지)
-        let inputNode = audioEngine.inputNode
-        inputNode.removeTap(onBus: 0)
-        let recordingFormat = inputNode.outputFormat(forBus: 0)
-
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { [weak self] buffer, _ in
-            self?.recognitionRequest?.append(buffer)
-        }
-
-        // 오디오 엔진 시작
-        audioEngine.prepare()
-        try audioEngine.start()
+        try startRecognitionSession()
+        startElapsedTimer()
+        startChunkTimer()
 
         DispatchQueue.main.async {
             self.isRecording = true
@@ -162,41 +104,68 @@ final class SpeechRecognitionManager: NSObject {
         }
     }
 
-    /// 녹음 중지
     func stopRecording() {
-        stopRecordingInternal()
-    }
-
-    private func stopRecordingInternal() {
-        // 이미 중지 상태면 무시
-        guard audioEngine.isRunning || recognitionRequest != nil else {
-            DispatchQueue.main.async {
-                self.isRecording = false
-            }
-            return
-        }
-
-        // 오디오 엔진 중지
-        if audioEngine.isRunning {
-            audioEngine.stop()
-            audioEngine.inputNode.removeTap(onBus: 0)
-        }
-
-        // 인식 요청 종료 (최종 결과를 받기 위해 endAudio만 호출)
+        stopChunkTimer()
+        stopElapsedTimer()
+        stopAudioEngine()
         recognitionRequest?.endAudio()
 
-        // 오디오 세션 비활성화
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
 
         DispatchQueue.main.async {
             self.isRecording = false
+            self.isPaused = false
+            self.audioLevel = 0
         }
-
-        // 인식 작업은 취소하지 않음 - 자연스럽게 완료되도록 함
-        // recognitionTask가 완료되면 콜백에서 정리됨
     }
 
-    /// 녹음 토글
+    func pauseRecording() {
+        guard isRecording, !isPaused else { return }
+
+        stopChunkTimer()
+        stopElapsedTimer()
+
+        // 현재 인식 중인 텍스트를 누적에 병합 후 스냅샷
+        let current = recognizedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !current.isEmpty {
+            accumulatedText = accumulatedText.isEmpty ? current : accumulatedText + "\n" + current
+        }
+        pauseSnapshot = accumulatedText
+
+        stopAudioEngine()
+        recognitionRequest?.endAudio()
+        recognitionRequest = nil
+        recognitionTask?.cancel()
+        recognitionTask = nil
+
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+
+        DispatchQueue.main.async {
+            self.isPaused = true
+            self.audioLevel = 0
+            self.recognizedText = self.accumulatedText
+        }
+    }
+
+    func resumeRecording() {
+        guard isRecording, isPaused else { return }
+
+        do {
+            accumulatedText = pauseSnapshot
+            try startRecognitionSession()
+            startElapsedTimer()
+            startChunkTimer()
+            DispatchQueue.main.async {
+                self.isPaused = false
+                self.errorMessage = nil
+            }
+        } catch {
+            DispatchQueue.main.async {
+                self.errorMessage = L.Voice.errorRecordingFailed
+            }
+        }
+    }
+
     func toggleRecording() {
         if isRecording {
             stopRecording()
@@ -211,9 +180,175 @@ final class SpeechRecognitionManager: NSObject {
         }
     }
 
-    /// 텍스트 초기화
+    func togglePause() {
+        if isPaused {
+            resumeRecording()
+        } else {
+            pauseRecording()
+        }
+    }
+
     func clearText() {
         recognizedText = ""
+        accumulatedText = ""
+    }
+
+    // MARK: - Private: Session Management
+
+    private func startRecognitionSession() throws {
+        if recognitionTask != nil {
+            recognitionTask?.cancel()
+            recognitionTask = nil
+        }
+
+        let audioSession = AVAudioSession.sharedInstance()
+        // 블루투스/에어팟 마이크 지원 + 음성 최적화 모드
+        try audioSession.setCategory(
+            .record,
+            mode: .default,
+            options: [.allowBluetooth, .allowBluetoothA2DP]
+        )
+        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+
+        recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
+        guard let recognitionRequest else {
+            throw SpeechRecognitionError.requestCreationFailed
+        }
+        recognitionRequest.shouldReportPartialResults = true
+
+        guard let speechRecognizer, speechRecognizer.isAvailable else {
+            throw SpeechRecognitionError.recognizerNotAvailable
+        }
+
+        let accumulated = accumulatedText
+
+        recognitionTask = speechRecognizer.recognitionTask(with: recognitionRequest) { [weak self] result, error in
+            guard let self else { return }
+
+            if let result {
+                let chunk = result.bestTranscription.formattedString
+                let full = accumulated.isEmpty ? chunk : accumulated + "\n" + chunk
+                DispatchQueue.main.async {
+                    self.recognizedText = full
+                }
+
+                if result.isFinal {
+                    let finalChunk = result.bestTranscription.formattedString.trimmingCharacters(in: .whitespacesAndNewlines)
+                    DispatchQueue.main.async {
+                        self.accumulatedText = accumulated.isEmpty
+                            ? finalChunk
+                            : accumulated + "\n" + finalChunk
+                    }
+                }
+            }
+
+            if error != nil && !self.isPaused {
+                if self.audioEngine.isRunning {
+                    self.audioEngine.stop()
+                    self.audioEngine.inputNode.removeTap(onBus: 0)
+                }
+                try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+                DispatchQueue.main.async {
+                    self.recognitionRequest = nil
+                    self.recognitionTask = nil
+                    if !self.isRecording { return }
+                    self.isRecording = false
+                    self.audioLevel = 0
+                }
+            }
+        }
+
+        let inputNode = audioEngine.inputNode
+        inputNode.removeTap(onBus: 0)
+        let recordingFormat = inputNode.outputFormat(forBus: 0)
+
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { [weak self] buffer, _ in
+            self?.recognitionRequest?.append(buffer)
+            self?.updateAudioLevel(buffer: buffer)
+        }
+
+        audioEngine.prepare()
+        try audioEngine.start()
+    }
+
+    private func stopAudioEngine() {
+        guard audioEngine.isRunning else { return }
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+    }
+
+    // MARK: - Private: Chunking
+
+    private func startChunkTimer() {
+        chunkTimer?.invalidate()
+        chunkTimer = Timer.scheduledTimer(withTimeInterval: chunkInterval, repeats: false) { [weak self] _ in
+            self?.rotateChunk()
+        }
+    }
+
+    private func stopChunkTimer() {
+        chunkTimer?.invalidate()
+        chunkTimer = nil
+    }
+
+    /// 55초 경과 시 현재 텍스트를 누적하고 새 인식 세션 시작 (무중단)
+    private func rotateChunk() {
+        guard isRecording, !isPaused else { return }
+
+        // 현재 인식 중인 텍스트 누적
+        let current = recognizedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !current.isEmpty {
+            accumulatedText = accumulatedText.isEmpty ? current : accumulatedText + "\n" + current
+        }
+
+        // 기존 세션 정리
+        stopAudioEngine()
+        recognitionRequest?.endAudio()
+        recognitionRequest = nil
+        recognitionTask?.cancel()
+        recognitionTask = nil
+
+        // 새 세션 즉시 시작
+        do {
+            try startRecognitionSession()
+            startChunkTimer() // 다시 55초 타이머
+        } catch {
+            DispatchQueue.main.async {
+                self.errorMessage = L.Voice.errorRecordingFailed
+            }
+        }
+    }
+
+    // MARK: - Private: Elapsed Timer
+
+    private func startElapsedTimer() {
+        elapsedTimer?.invalidate()
+        elapsedTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            DispatchQueue.main.async {
+                self?.elapsedSeconds += 1
+            }
+        }
+    }
+
+    private func stopElapsedTimer() {
+        elapsedTimer?.invalidate()
+        elapsedTimer = nil
+    }
+
+    // MARK: - Private: Audio Level Metering
+
+    private func updateAudioLevel(buffer: AVAudioPCMBuffer) {
+        guard let channelData = buffer.floatChannelData?[0] else { return }
+        let frameCount = vDSP_Length(buffer.frameLength)
+        guard frameCount > 0 else { return }
+
+        var rms: Float = 0.0
+        vDSP_rmsqv(channelData, 1, &rms, frameCount)
+        let normalized = min(rms * 20, 1.0)
+
+        DispatchQueue.main.async {
+            self.audioLevel = normalized
+        }
     }
 }
 
@@ -239,14 +374,10 @@ enum SpeechRecognitionError: Error, LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .requestCreationFailed:
-            return L.Voice.errorRequestFailed
-        case .recognizerNotAvailable:
-            return L.Voice.errorRecognizerUnavailable
-        case .permissionDenied:
-            return L.Voice.errorPermissionDenied
-        case .audioSessionFailed:
-            return L.Voice.errorAudioSession
+        case .requestCreationFailed:   return L.Voice.errorRequestFailed
+        case .recognizerNotAvailable:  return L.Voice.errorRecognizerUnavailable
+        case .permissionDenied:        return L.Voice.errorPermissionDenied
+        case .audioSessionFailed:      return L.Voice.errorAudioSession
         }
     }
 }

--- a/PrayAnswer/Views/Components/MyPrayerBannerView.swift
+++ b/PrayAnswer/Views/Components/MyPrayerBannerView.swift
@@ -40,34 +40,40 @@ struct MyPrayerBannerView: View {
                 }
 
                 if isExpanded {
-                    if prayers.isEmpty {
-                        // 비어있을 때
-                        Text("다른 사람이 나를 위해 기도해줄 내용을 추가해보세요.")
-                            .font(DesignSystem.Typography.caption)
-                            .foregroundColor(DesignSystem.Colors.secondaryText)
-                            .padding(.vertical, DesignSystem.Spacing.xs)
-                    } else {
-                        // 기도제목 목록 (최대 3개 미리보기)
-                        ForEach(prayers.prefix(3)) { prayer in
-                            HStack(spacing: DesignSystem.Spacing.sm) {
-                                Circle()
-                                    .fill(prayer.category.color.opacity(0.3))
-                                    .frame(width: 6, height: 6)
-                                Text(prayer.content.isEmpty ? prayer.title : prayer.content)
-                                    .font(DesignSystem.Typography.caption)
-                                    .foregroundColor(DesignSystem.Colors.primaryText)
+                    VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                        if prayers.isEmpty {
+                            // 비어있을 때
+                            Text("다른 사람이 나를 위해 기도해줄 내용을 추가해보세요.")
+                                .font(DesignSystem.Typography.caption)
+                                .foregroundColor(DesignSystem.Colors.secondaryText)
+                                .padding(.vertical, DesignSystem.Spacing.xs)
+                        } else {
+                            // 기도제목 목록 (최대 3개 미리보기)
+                            ForEach(prayers.prefix(3)) { prayer in
+                                HStack(spacing: DesignSystem.Spacing.sm) {
+                                    Circle()
+                                        .fill(prayer.category.color.opacity(0.3))
+                                        .frame(width: 6, height: 6)
+                                    Text(prayer.content.isEmpty ? prayer.title : prayer.content)
+                                        .font(DesignSystem.Typography.caption)
+                                        .foregroundColor(DesignSystem.Colors.primaryText)
+                                }
+                            }
+                            if prayers.count > 3 {
+                                Text("외 \(prayers.count - 3)개")
+                                    .font(DesignSystem.Typography.caption2)
+                                    .foregroundColor(DesignSystem.Colors.tertiaryText)
                             }
                         }
-                        if prayers.count > 3 {
-                            Text("외 \(prayers.count - 3)개")
-                                .font(DesignSystem.Typography.caption2)
-                                .foregroundColor(DesignSystem.Colors.tertiaryText)
-                        }
                     }
-
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    // 펼침: 위에서 아래로 내려오고, 접힘: 위로 올라가 사라짐
+                    .transition(.move(edge: .top).combined(with: .opacity))
                 }
             }
             .padding(DesignSystem.Spacing.md)
+            // 펼쳐지는 콘텐츠가 카드 밖으로 넘치지 않도록 클리핑
+            .clipped()
         }
     }
 }

--- a/PrayAnswer/Views/FeatureGuideView.swift
+++ b/PrayAnswer/Views/FeatureGuideView.swift
@@ -1,0 +1,85 @@
+//
+//  FeatureGuideView.swift
+//  PrayAnswer
+//
+//  설정에서 진입하는 사용법 안내 화면
+//
+
+import SwiftUI
+
+struct FeatureGuideView: View {
+    var body: some View {
+        List {
+            ForEach(guideItems, id: \.title) { item in
+                FeatureGuideRow(icon: item.icon, color: item.color, title: item.title, description: item.description)
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle(L.Settings.guideSection)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    // MARK: - Guide Items Data
+
+    private var guideItems: [GuideItem] {
+        [
+            GuideItem(icon: "hands.clap.fill",   color: DesignSystem.Colors.primary,      title: L.Guide.addPrayerTitle,   description: L.Guide.addPrayerDesc),
+            GuideItem(icon: "tray.2.fill",        color: DesignSystem.Colors.wait,         title: L.Guide.storageTitle,     description: L.Guide.storageDesc),
+            GuideItem(icon: "person.2.fill",      color: Color.blue,                       title: L.Guide.peopleTitle,      description: L.Guide.peopleDesc),
+            GuideItem(icon: "heart.fill",         color: Color.red,                        title: L.Guide.favoriteTitle,    description: L.Guide.favoriteDesc),
+            GuideItem(icon: "clock.badge.checkmark", color: Color.orange,                  title: L.Guide.habitTitle,       description: L.Guide.habitDesc),
+            GuideItem(icon: "rectangle.3.group.fill", color: Color.indigo,                 title: L.Guide.widgetTitle,      description: L.Guide.widgetDesc),
+            GuideItem(icon: "arrow.triangle.2.circlepath", color: DesignSystem.Colors.answered, title: L.Guide.exchangeTitle, description: L.Guide.exchangeDesc),
+            GuideItem(icon: "square.and.arrow.up.fill", color: Color.teal,                 title: L.Guide.shareExtTitle,    description: L.Guide.shareExtDesc),
+            GuideItem(icon: "folder.fill",        color: Color.yellow,                     title: L.Guide.collectionTitle,  description: L.Guide.collectionDesc),
+            GuideItem(icon: "checkmark.seal.fill", color: DesignSystem.Colors.answered,    title: L.Guide.answerNoteTitle,  description: L.Guide.answerNoteDesc),
+            GuideItem(icon: "mic.fill",           color: Color.purple,                     title: L.Guide.voiceAITitle,     description: L.Guide.voiceAIDesc),
+        ]
+    }
+}
+
+// MARK: - Supporting Types
+
+private struct GuideItem {
+    let icon: String
+    let color: Color
+    let title: String
+    let description: String
+}
+
+private struct FeatureGuideRow: View {
+    let icon: String
+    let color: Color
+    let title: String
+    let description: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+            ZStack {
+                RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.small)
+                    .fill(color.opacity(0.15))
+                    .frame(width: 36, height: 36)
+                Image(systemName: icon)
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundColor(color)
+            }
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(DesignSystem.Typography.callout)
+                    .foregroundColor(DesignSystem.Colors.primaryText)
+                Text(description)
+                    .font(DesignSystem.Typography.caption2)
+                    .foregroundColor(DesignSystem.Colors.secondaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.vertical, DesignSystem.Spacing.xs)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        FeatureGuideView()
+    }
+}

--- a/PrayAnswer/Views/SettingsView.swift
+++ b/PrayAnswer/Views/SettingsView.swift
@@ -4,7 +4,6 @@
 //
 
 import SwiftUI
-import StoreKit
 
 struct SettingsView: View {
     @State private var showStatistics = false
@@ -36,11 +35,18 @@ struct SettingsView: View {
 
     private var guideSection: some View {
         Section {
-            ForEach(guideItems, id: \.title) { item in
-                FeatureGuideRow(icon: item.icon, color: item.color, title: item.title, description: item.description)
+            NavigationLink {
+                FeatureGuideView()
+            } label: {
+                Label {
+                    Text(L.Settings.guideSection)
+                        .font(DesignSystem.Typography.callout)
+                        .foregroundColor(DesignSystem.Colors.primaryText)
+                } icon: {
+                    Image(systemName: "book")
+                        .foregroundColor(DesignSystem.Colors.primary)
+                }
             }
-        } header: {
-            Text(L.Settings.guideSection)
         }
     }
 
@@ -131,20 +137,18 @@ struct SettingsView: View {
             }
 
             Button {
-                let email = "eunkwanbear@gmail.com"
-                let subject = "PrayAnswer 문의"
-                let urlString = "mailto:\(email)?subject=\(subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")"
-                if let url = URL(string: urlString) {
+                if let url = URL(string: "https://www.instagram.com/mordecai_kwan") {
                     UIApplication.shared.open(url)
                 }
             } label: {
-                Label(L.Settings.contact, systemImage: "envelope")
+                Label(L.Settings.contact, systemImage: "message")
                     .foregroundColor(DesignSystem.Colors.primaryText)
             }
 
             Button {
-                if let scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
-                    AppStore.requestReview(in: scene)
+                // 지역 코드(/kr/) 포함 URL 재사용 — 미포함 시 기본 스토어프론트로 연결돼 "지역에서 사용 불가" 오류 발생
+                if let url = URL(string: "\(PrayerExchangePackager.appStoreURL)?action=write-review") {
+                    UIApplication.shared.open(url)
                 }
             } label: {
                 Label(L.Settings.review, systemImage: "star")
@@ -152,7 +156,7 @@ struct SettingsView: View {
             }
 
             Button {
-                if let url = URL(string: "https://sites.google.com/view/prayanswer-privacy") {
+                if let url = URL(string: "https://www.notion.so/prayanswer-2a1d59d95c59809fb0aac3ec8ba026e6?source=copy_link") {
                     UIApplication.shared.open(url)
                 }
             } label: {
@@ -162,64 +166,6 @@ struct SettingsView: View {
         } header: {
             Text(L.Settings.appSection)
         }
-    }
-
-    // MARK: - Guide Items Data
-
-    private var guideItems: [GuideItem] {
-        [
-            GuideItem(icon: "hands.clap.fill",   color: DesignSystem.Colors.primary,      title: L.Guide.addPrayerTitle,   description: L.Guide.addPrayerDesc),
-            GuideItem(icon: "tray.2.fill",        color: DesignSystem.Colors.wait,         title: L.Guide.storageTitle,     description: L.Guide.storageDesc),
-            GuideItem(icon: "person.2.fill",      color: Color.blue,                       title: L.Guide.peopleTitle,      description: L.Guide.peopleDesc),
-            GuideItem(icon: "heart.fill",         color: Color.red,                        title: L.Guide.favoriteTitle,    description: L.Guide.favoriteDesc),
-            GuideItem(icon: "clock.badge.checkmark", color: Color.orange,                  title: L.Guide.habitTitle,       description: L.Guide.habitDesc),
-            GuideItem(icon: "rectangle.3.group.fill", color: Color.indigo,                 title: L.Guide.widgetTitle,      description: L.Guide.widgetDesc),
-            GuideItem(icon: "arrow.triangle.2.circlepath", color: DesignSystem.Colors.answered, title: L.Guide.exchangeTitle, description: L.Guide.exchangeDesc),
-            GuideItem(icon: "square.and.arrow.up.fill", color: Color.teal,                 title: L.Guide.shareExtTitle,    description: L.Guide.shareExtDesc),
-            GuideItem(icon: "folder.fill",        color: Color.yellow,                     title: L.Guide.collectionTitle,  description: L.Guide.collectionDesc),
-            GuideItem(icon: "checkmark.seal.fill", color: DesignSystem.Colors.answered,    title: L.Guide.answerNoteTitle,  description: L.Guide.answerNoteDesc),
-            GuideItem(icon: "mic.fill",           color: Color.purple,                     title: L.Guide.voiceAITitle,     description: L.Guide.voiceAIDesc),
-        ]
-    }
-}
-
-// MARK: - Supporting Types
-
-private struct GuideItem {
-    let icon: String
-    let color: Color
-    let title: String
-    let description: String
-}
-
-private struct FeatureGuideRow: View {
-    let icon: String
-    let color: Color
-    let title: String
-    let description: String
-
-    var body: some View {
-        HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
-            ZStack {
-                RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.small)
-                    .fill(color.opacity(0.15))
-                    .frame(width: 36, height: 36)
-                Image(systemName: icon)
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(color)
-            }
-
-            VStack(alignment: .leading, spacing: 3) {
-                Text(title)
-                    .font(DesignSystem.Typography.callout)
-                    .foregroundColor(DesignSystem.Colors.primaryText)
-                Text(description)
-                    .font(DesignSystem.Typography.caption2)
-                    .foregroundColor(DesignSystem.Colors.secondaryText)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-        }
-        .padding(.vertical, DesignSystem.Spacing.xs)
     }
 }
 

--- a/PrayAnswer/Views/SettingsView.swift
+++ b/PrayAnswer/Views/SettingsView.swift
@@ -1,0 +1,228 @@
+//
+//  SettingsView.swift
+//  PrayAnswer
+//
+
+import SwiftUI
+import StoreKit
+
+struct SettingsView: View {
+    @State private var showStatistics = false
+    @AppStorage("aiFeatureEnabled") private var isAIUserEnabled: Bool = true
+
+    private var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "-"
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                guideSection
+                aiSection
+                statsSection
+                appInfoSection
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle(L.Settings.tabTitle)
+        }
+        .sheet(isPresented: $showStatistics) {
+            StatisticsView()
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+        }
+    }
+
+    // MARK: - Sections
+
+    private var guideSection: some View {
+        Section {
+            ForEach(guideItems, id: \.title) { item in
+                FeatureGuideRow(icon: item.icon, color: item.color, title: item.title, description: item.description)
+            }
+        } header: {
+            Text(L.Settings.guideSection)
+        }
+    }
+
+    private var aiSection: some View {
+        Section {
+            Toggle(isOn: $isAIUserEnabled) {
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "sparkles")
+                            .foregroundStyle(
+                                LinearGradient(colors: [.purple, .cyan], startPoint: .leading, endPoint: .trailing)
+                            )
+                        Text(L.Settings.aiToggle)
+                            .font(DesignSystem.Typography.callout)
+                            .foregroundColor(DesignSystem.Colors.primaryText)
+                    }
+                    Text(L.Settings.aiToggleDesc)
+                        .font(DesignSystem.Typography.caption2)
+                        .foregroundColor(DesignSystem.Colors.secondaryText)
+                }
+            }
+            .tint(DesignSystem.Colors.primary)
+
+            HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+                Image(systemName: "airpodspro")
+                    .font(.body)
+                    .foregroundColor(.blue)
+                    .frame(width: 24)
+                Text(L.Settings.bluetoothTip)
+                    .font(DesignSystem.Typography.footnote)
+                    .foregroundColor(DesignSystem.Colors.secondaryText)
+            }
+            .listRowSeparator(.hidden)
+
+            HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+                Image(systemName: "clock.arrow.2.circlepath")
+                    .font(.body)
+                    .foregroundColor(.orange)
+                    .frame(width: 24)
+                Text(L.Settings.voiceChunkingTip)
+                    .font(DesignSystem.Typography.footnote)
+                    .foregroundColor(DesignSystem.Colors.secondaryText)
+            }
+        } header: {
+            Text(L.Settings.aiSection)
+        }
+    }
+
+    private var statsSection: some View {
+        Section {
+            Button {
+                showStatistics = true
+            } label: {
+                HStack {
+                    Label {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(L.Settings.statsButton)
+                                .font(DesignSystem.Typography.callout)
+                                .foregroundColor(DesignSystem.Colors.primaryText)
+                            Text(L.Settings.statsDesc)
+                                .font(DesignSystem.Typography.caption2)
+                                .foregroundColor(DesignSystem.Colors.secondaryText)
+                        }
+                    } icon: {
+                        Image(systemName: "chart.bar.xaxis")
+                            .foregroundColor(DesignSystem.Colors.primary)
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundColor(DesignSystem.Colors.tertiaryText)
+                }
+            }
+            .buttonStyle(PlainButtonStyle())
+        } header: {
+            Text(L.Settings.statsSection)
+        }
+    }
+
+    private var appInfoSection: some View {
+        Section {
+            HStack {
+                Text(L.Settings.version)
+                    .foregroundColor(DesignSystem.Colors.primaryText)
+                Spacer()
+                Text(appVersion)
+                    .foregroundColor(DesignSystem.Colors.secondaryText)
+            }
+
+            Button {
+                let email = "eunkwanbear@gmail.com"
+                let subject = "PrayAnswer 문의"
+                let urlString = "mailto:\(email)?subject=\(subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")"
+                if let url = URL(string: urlString) {
+                    UIApplication.shared.open(url)
+                }
+            } label: {
+                Label(L.Settings.contact, systemImage: "envelope")
+                    .foregroundColor(DesignSystem.Colors.primaryText)
+            }
+
+            Button {
+                if let scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+                    AppStore.requestReview(in: scene)
+                }
+            } label: {
+                Label(L.Settings.review, systemImage: "star")
+                    .foregroundColor(DesignSystem.Colors.primaryText)
+            }
+
+            Button {
+                if let url = URL(string: "https://sites.google.com/view/prayanswer-privacy") {
+                    UIApplication.shared.open(url)
+                }
+            } label: {
+                Label(L.Settings.privacyPolicy, systemImage: "lock.shield")
+                    .foregroundColor(DesignSystem.Colors.primaryText)
+            }
+        } header: {
+            Text(L.Settings.appSection)
+        }
+    }
+
+    // MARK: - Guide Items Data
+
+    private var guideItems: [GuideItem] {
+        [
+            GuideItem(icon: "hands.clap.fill",   color: DesignSystem.Colors.primary,      title: L.Guide.addPrayerTitle,   description: L.Guide.addPrayerDesc),
+            GuideItem(icon: "tray.2.fill",        color: DesignSystem.Colors.wait,         title: L.Guide.storageTitle,     description: L.Guide.storageDesc),
+            GuideItem(icon: "person.2.fill",      color: Color.blue,                       title: L.Guide.peopleTitle,      description: L.Guide.peopleDesc),
+            GuideItem(icon: "heart.fill",         color: Color.red,                        title: L.Guide.favoriteTitle,    description: L.Guide.favoriteDesc),
+            GuideItem(icon: "clock.badge.checkmark", color: Color.orange,                  title: L.Guide.habitTitle,       description: L.Guide.habitDesc),
+            GuideItem(icon: "rectangle.3.group.fill", color: Color.indigo,                 title: L.Guide.widgetTitle,      description: L.Guide.widgetDesc),
+            GuideItem(icon: "arrow.triangle.2.circlepath", color: DesignSystem.Colors.answered, title: L.Guide.exchangeTitle, description: L.Guide.exchangeDesc),
+            GuideItem(icon: "square.and.arrow.up.fill", color: Color.teal,                 title: L.Guide.shareExtTitle,    description: L.Guide.shareExtDesc),
+            GuideItem(icon: "folder.fill",        color: Color.yellow,                     title: L.Guide.collectionTitle,  description: L.Guide.collectionDesc),
+            GuideItem(icon: "checkmark.seal.fill", color: DesignSystem.Colors.answered,    title: L.Guide.answerNoteTitle,  description: L.Guide.answerNoteDesc),
+            GuideItem(icon: "mic.fill",           color: Color.purple,                     title: L.Guide.voiceAITitle,     description: L.Guide.voiceAIDesc),
+        ]
+    }
+}
+
+// MARK: - Supporting Types
+
+private struct GuideItem {
+    let icon: String
+    let color: Color
+    let title: String
+    let description: String
+}
+
+private struct FeatureGuideRow: View {
+    let icon: String
+    let color: Color
+    let title: String
+    let description: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+            ZStack {
+                RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.small)
+                    .fill(color.opacity(0.15))
+                    .frame(width: 36, height: 36)
+                Image(systemName: icon)
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundColor(color)
+            }
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(DesignSystem.Typography.callout)
+                    .foregroundColor(DesignSystem.Colors.primaryText)
+                Text(description)
+                    .font(DesignSystem.Typography.caption2)
+                    .foregroundColor(DesignSystem.Colors.secondaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.vertical, DesignSystem.Spacing.xs)
+    }
+}
+
+#Preview {
+    SettingsView()
+}

--- a/PrayAnswer/Views/UIComponents.swift
+++ b/PrayAnswer/Views/UIComponents.swift
@@ -1363,7 +1363,7 @@ struct VoiceRecordingButton: View {
     }
 }
 
-/// 음성 녹음 오버레이 - 녹음 중 전체 화면 표시 (AI 정리 기능 포함)
+/// 음성 녹음 오버레이 - 파형 시각화·타이머·일시정지 포함
 struct VoiceRecordingOverlay: View {
     @Bindable var speechManager: SpeechRecognitionManager
     let onUseText: (String) -> Void
@@ -1374,348 +1374,65 @@ struct VoiceRecordingOverlay: View {
     @State private var showAISummaryPreview = false
     @State private var summarizedText = ""
     @State private var aiErrorMessage: String?
+    @State private var waveformLevels: [Float] = Array(repeating: 0.15, count: 7)
 
-    /// AI 사용자 설정 (AppStorage 연동)
     @AppStorage("aiFeatureEnabled") private var isAIUserEnabled: Bool = true
 
-    /// AI 기능 사용 가능 여부 (시스템 지원 + 사용자 활성화)
-    private var isAIAvailable: Bool {
-        AIFeatureAvailability.isSupported
-    }
+    private var isAIAvailable: Bool { AIFeatureAvailability.isSupported }
+    private var isAISystemSupported: Bool { AIFeatureAvailability.isSystemSupported }
 
-    /// 시스템이 AI를 지원하는지 여부 (사용자 설정과 무관)
-    private var isAISystemSupported: Bool {
-        AIFeatureAvailability.isSystemSupported
+    private var timerString: String {
+        let m = speechManager.elapsedSeconds / 60
+        let s = speechManager.elapsedSeconds % 60
+        return String(format: "%02d:%02d", m, s)
     }
 
     var body: some View {
         ZStack {
-            // 배경 블러
-            Color.black.opacity(0.6)
+            Color.black.opacity(0.75)
                 .ignoresSafeArea()
                 .contentShape(Rectangle())
                 .onTapGesture {
-                    // 배경 탭으로 취소
-                    if !speechManager.isRecording && !isAIProcessing {
-                        onCancel()
-                    }
+                    if !speechManager.isRecording && !isAIProcessing { onCancel() }
                 }
                 .zIndex(0)
 
-            VStack(spacing: DesignSystem.Spacing.xxl) {
-                // AI 토글 버튼 (시스템이 지원하는 경우에만 표시)
-                if isAISystemSupported {
-                    HStack {
-                        Spacer()
-                        Button(action: {
-                            withAnimation(.easeInOut(duration: 0.2)) {
-                                isAIUserEnabled.toggle()
-                            }
-                        }) {
-                            HStack(spacing: DesignSystem.Spacing.xs) {
-                                Image(systemName: isAIUserEnabled ? "sparkles" : "sparkles.slash")
-                                    .font(.body)
-                                Text(isAIUserEnabled ? "AI ON" : "AI OFF")
-                                    .font(DesignSystem.Typography.callout)
-                                    .fontWeight(.medium)
-                            }
-                            .foregroundColor(isAIUserEnabled ? .cyan : .white.opacity(0.5))
-                            .padding(.horizontal, DesignSystem.Spacing.lg)
-                            .padding(.vertical, DesignSystem.Spacing.md)
-                            .background(
-                                isAIUserEnabled
-                                    ? LinearGradient(
-                                        colors: [.purple.opacity(0.3), .blue.opacity(0.3), .cyan.opacity(0.3)],
-                                        startPoint: .leading,
-                                        endPoint: .trailing
-                                    )
-                                    : LinearGradient(
-                                        colors: [.white.opacity(0.1), .white.opacity(0.1)],
-                                        startPoint: .leading,
-                                        endPoint: .trailing
-                                    )
-                            )
-                            .cornerRadius(DesignSystem.CornerRadius.medium)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.medium)
-                                    .stroke(
-                                        isAIUserEnabled
-                                            ? LinearGradient(
-                                                colors: [.purple.opacity(0.5), .cyan.opacity(0.5)],
-                                                startPoint: .leading,
-                                                endPoint: .trailing
-                                            )
-                                            : LinearGradient(
-                                                colors: [.white.opacity(0.2), .white.opacity(0.2)],
-                                                startPoint: .leading,
-                                                endPoint: .trailing
-                                            ),
-                                        lineWidth: 1
-                                    )
-                            )
-                        }
-                        .buttonStyle(PlainButtonStyle())
-                        .disabled(isAIProcessing)
-                    }
-                    .padding(.horizontal, DesignSystem.Spacing.xl)
+            VStack(spacing: 0) {
+                // ── 상단: AI 토글
+                topBar
                     .padding(.top, DesignSystem.Spacing.xl)
-                }
 
                 Spacer()
 
-                // 녹음 상태 인디케이터
-                ZStack {
-                    // 펄스 애니메이션 원
-                    if speechManager.isRecording {
-                        Circle()
-                            .fill(DesignSystem.Colors.primary.opacity(0.3))
-                            .frame(width: 160, height: 160)
-                            .scaleEffect(pulseAnimation ? 1.2 : 1.0)
-                            .opacity(pulseAnimation ? 0 : 0.5)
-                            .animation(
-                                .easeInOut(duration: 1.0).repeatForever(autoreverses: false),
-                                value: pulseAnimation
-                            )
-
-                        Circle()
-                            .fill(DesignSystem.Colors.primary.opacity(0.2))
-                            .frame(width: 140, height: 140)
-                            .scaleEffect(pulseAnimation ? 1.3 : 1.0)
-                            .opacity(pulseAnimation ? 0 : 0.3)
-                            .animation(
-                                .easeInOut(duration: 1.0).repeatForever(autoreverses: false).delay(0.3),
-                                value: pulseAnimation
-                            )
-                    }
-
-                    // AI 처리 중 애니메이션
-                    if isAIProcessing {
-                        Circle()
-                            .fill(
-                                LinearGradient(
-                                    colors: [.purple.opacity(0.3), .blue.opacity(0.3), .cyan.opacity(0.3)],
-                                    startPoint: .topLeading,
-                                    endPoint: .bottomTrailing
-                                )
-                            )
-                            .frame(width: 160, height: 160)
-                            .scaleEffect(pulseAnimation ? 1.2 : 1.0)
-                            .opacity(pulseAnimation ? 0 : 0.5)
-                            .animation(
-                                .easeInOut(duration: 1.5).repeatForever(autoreverses: true),
-                                value: pulseAnimation
-                            )
-                    }
-
-                    // 마이크/AI 버튼
-                    Button(action: {
-                        if !isAIProcessing {
-                            speechManager.toggleRecording()
-                        }
-                    }) {
-                        Circle()
-                            .fill(
-                                isAIProcessing
-                                    ? LinearGradient(
-                                        colors: [.purple, .blue, .cyan],
-                                        startPoint: .topLeading,
-                                        endPoint: .bottomTrailing
-                                    )
-                                    : LinearGradient(
-                                        colors: [speechManager.isRecording ? .red : DesignSystem.Colors.primary,
-                                                 speechManager.isRecording ? .red : DesignSystem.Colors.primary],
-                                        startPoint: .topLeading,
-                                        endPoint: .bottomTrailing
-                                    )
-                            )
-                            .frame(width: 120, height: 120)
-                            .shadow(
-                                color: (speechManager.isRecording ? Color.red : DesignSystem.Colors.primary).opacity(0.4),
-                                radius: 20,
-                                x: 0,
-                                y: 10
-                            )
-                            .overlay(
-                                Group {
-                                    if isAIProcessing {
-                                        ProgressView()
-                                            .progressViewStyle(CircularProgressViewStyle(tint: .white))
-                                            .scaleEffect(2)
-                                    } else {
-                                        Image(systemName: speechManager.isRecording ? "stop.fill" : "mic.fill")
-                                            .font(.system(size: 50, weight: .medium))
-                                            .foregroundColor(.white)
-                                    }
-                                }
-                            )
-                    }
-                    .buttonStyle(PlainButtonStyle())
-                    .disabled(isAIProcessing)
-                }
-                .onAppear {
-                    pulseAnimation = true
+                // ── 중앙: 마이크 버튼 + 파형
+                VStack(spacing: DesignSystem.Spacing.xl) {
+                    micButton
+                    waveformView
+                    statusLabel
                 }
 
-                // 상태 텍스트
-                VStack(spacing: DesignSystem.Spacing.md) {
-                    if isAIProcessing {
-                        Text(L.AI.summarizing)
-                            .font(DesignSystem.Typography.headline)
-                            .foregroundStyle(
-                                LinearGradient(
-                                    colors: [.purple, .blue, .cyan],
-                                    startPoint: .leading,
-                                    endPoint: .trailing
-                                )
-                            )
-                    } else {
-                        Text(speechManager.isRecording ? L.Voice.listening : L.Voice.tapToStart)
-                            .font(DesignSystem.Typography.headline)
-                            .foregroundColor(.white)
-                    }
-
-                    if let errorMessage = speechManager.errorMessage ?? aiErrorMessage {
-                        Text(errorMessage)
-                            .font(DesignSystem.Typography.caption)
-                            .foregroundColor(Color.red.opacity(0.9))
-                            .multilineTextAlignment(.center)
-                            .padding(.horizontal, DesignSystem.Spacing.xl)
-                    }
-                }
-
-                // 인식된 텍스트 표시
+                // ── 인식 텍스트
                 if !speechManager.recognizedText.isEmpty {
-                    VStack(spacing: DesignSystem.Spacing.md) {
-                        ScrollView {
-                            Text(speechManager.recognizedText)
-                                .font(DesignSystem.Typography.body)
-                                .foregroundColor(.white)
-                                .multilineTextAlignment(.center)
-                                .padding(DesignSystem.Spacing.lg)
-                        }
-                        .frame(maxHeight: 200)
-                        .background(Color.black.opacity(0.5))
-                        .cornerRadius(DesignSystem.CornerRadius.medium)
-                        .padding(.horizontal, DesignSystem.Spacing.xl)
-                    }
+                    recognizedTextBox
+                        .padding(.top, DesignSystem.Spacing.lg)
                 }
 
                 Spacer()
 
-                // 하단 버튼
-                VStack(spacing: DesignSystem.Spacing.md) {
-                    // 녹음 중일 때 명시적 중지 버튼
-                    if speechManager.isRecording {
-                        Button(action: {
-                            speechManager.stopRecording()
-                        }) {
-                            HStack(spacing: DesignSystem.Spacing.sm) {
-                                Image(systemName: "stop.circle.fill")
-                                Text(L.Voice.stopRecording)
-                            }
-                            .font(DesignSystem.Typography.headline)
-                            .foregroundColor(.red)
-                            .padding(.horizontal, DesignSystem.Spacing.xl)
-                            .padding(.vertical, DesignSystem.Spacing.md)
-                            .background(Color.red.opacity(0.2))
-                            .cornerRadius(DesignSystem.CornerRadius.large)
-                        }
-                        .buttonStyle(PlainButtonStyle())
-                    }
-
-                    // AI 정리 버튼 (텍스트가 있고 녹음이 완료된 경우에만)
-                    if !speechManager.recognizedText.isEmpty && !speechManager.isRecording && isAIAvailable {
-                        Button(action: {
-                            performAISummarization()
-                        }) {
-                            HStack(spacing: DesignSystem.Spacing.sm) {
-                                Image(systemName: "sparkles")
-                                Text(L.AI.summarize)
-                            }
-                            .font(DesignSystem.Typography.headline)
-                            .foregroundStyle(
-                                LinearGradient(
-                                    colors: [.purple, .blue, .cyan],
-                                    startPoint: .leading,
-                                    endPoint: .trailing
-                                )
-                            )
-                            .padding(.horizontal, DesignSystem.Spacing.xl)
-                            .padding(.vertical, DesignSystem.Spacing.md)
-                            .background(
-                                LinearGradient(
-                                    colors: [.purple.opacity(0.2), .blue.opacity(0.2), .cyan.opacity(0.2)],
-                                    startPoint: .leading,
-                                    endPoint: .trailing
-                                )
-                            )
-                            .cornerRadius(DesignSystem.CornerRadius.large)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.large)
-                                    .stroke(
-                                        LinearGradient(
-                                            colors: [.purple.opacity(0.5), .blue.opacity(0.5), .cyan.opacity(0.5)],
-                                            startPoint: .leading,
-                                            endPoint: .trailing
-                                        ),
-                                        lineWidth: 1
-                                    )
-                            )
-                        }
-                        .buttonStyle(PlainButtonStyle())
-                        .disabled(isAIProcessing)
-                    }
-
-                    HStack(spacing: DesignSystem.Spacing.xl) {
-                        // 취소 버튼
-                        Button(action: {
-                            speechManager.stopRecording()
-                            speechManager.clearText()
-                            onCancel()
-                        }) {
-                            HStack(spacing: DesignSystem.Spacing.sm) {
-                                Image(systemName: "xmark")
-                                Text(L.Voice.cancel)
-                            }
-                            .font(DesignSystem.Typography.headline)
-                            .foregroundColor(.white.opacity(0.8))
-                            .padding(.horizontal, DesignSystem.Spacing.xl)
-                            .padding(.vertical, DesignSystem.Spacing.md)
-                            .background(Color.white.opacity(0.2))
-                            .cornerRadius(DesignSystem.CornerRadius.large)
-                        }
-                        .buttonStyle(PlainButtonStyle())
-                        .disabled(isAIProcessing)
-
-                        // 텍스트 사용 버튼 (텍스트가 있을 때만)
-                        if !speechManager.recognizedText.isEmpty && !speechManager.isRecording {
-                            Button(action: {
-                                onUseText(speechManager.recognizedText)
-                                speechManager.clearText()
-                            }) {
-                                HStack(spacing: DesignSystem.Spacing.sm) {
-                                    Image(systemName: "checkmark")
-                                    Text(L.Voice.useText)
-                                }
-                                .font(DesignSystem.Typography.headline)
-                                .foregroundColor(.white)
-                                .padding(.horizontal, DesignSystem.Spacing.xl)
-                                .padding(.vertical, DesignSystem.Spacing.md)
-                                .background(DesignSystem.Colors.primary)
-                                .cornerRadius(DesignSystem.CornerRadius.large)
-                            }
-                            .buttonStyle(PlainButtonStyle())
-                            .disabled(isAIProcessing)
-                        }
-                    }
-                }
-                .padding(.bottom, DesignSystem.Spacing.xxxl)
+                // ── 하단: 타이머 + 컨트롤 버튼
+                bottomControls
+                    .padding(.bottom, DesignSystem.Spacing.xxxl)
             }
             .zIndex(1)
         }
         .animation(DesignSystem.Animation.standard, value: speechManager.isRecording)
+        .animation(DesignSystem.Animation.standard, value: speechManager.isPaused)
         .animation(DesignSystem.Animation.standard, value: speechManager.recognizedText)
         .animation(DesignSystem.Animation.standard, value: isAIProcessing)
+        .onChange(of: speechManager.audioLevel) { _, level in
+            updateWaveform(level: level)
+        }
+        .onAppear { pulseAnimation = true }
         .sheet(isPresented: $showAISummaryPreview) {
             AISummaryPreviewView(
                 originalText: speechManager.recognizedText,
@@ -1725,9 +1442,7 @@ struct VoiceRecordingOverlay: View {
                     speechManager.clearText()
                     showAISummaryPreview = false
                 },
-                onCancel: {
-                    showAISummaryPreview = false
-                },
+                onCancel: { showAISummaryPreview = false },
                 onRetry: {
                     showAISummaryPreview = false
                     performAISummarization()
@@ -1738,14 +1453,305 @@ struct VoiceRecordingOverlay: View {
         }
     }
 
+    // MARK: - Subviews
+
+    private var topBar: some View {
+        HStack {
+            Spacer()
+            if isAISystemSupported {
+                Button(action: {
+                    withAnimation(.easeInOut(duration: 0.2)) { isAIUserEnabled.toggle() }
+                }) {
+                    HStack(spacing: DesignSystem.Spacing.xs) {
+                        Image(systemName: isAIUserEnabled ? "sparkles" : "sparkles.slash")
+                            .font(.body)
+                        Text(isAIUserEnabled ? "AI ON" : "AI OFF")
+                            .font(DesignSystem.Typography.callout)
+                            .fontWeight(.medium)
+                    }
+                    .foregroundColor(isAIUserEnabled ? .cyan : .white.opacity(0.5))
+                    .padding(.horizontal, DesignSystem.Spacing.lg)
+                    .padding(.vertical, DesignSystem.Spacing.md)
+                    .background(
+                        isAIUserEnabled
+                            ? LinearGradient(colors: [.purple.opacity(0.3), .blue.opacity(0.3), .cyan.opacity(0.3)], startPoint: .leading, endPoint: .trailing)
+                            : LinearGradient(colors: [.white.opacity(0.1), .white.opacity(0.1)], startPoint: .leading, endPoint: .trailing)
+                    )
+                    .cornerRadius(DesignSystem.CornerRadius.medium)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.medium)
+                            .stroke(
+                                isAIUserEnabled
+                                    ? LinearGradient(colors: [.purple.opacity(0.5), .cyan.opacity(0.5)], startPoint: .leading, endPoint: .trailing)
+                                    : LinearGradient(colors: [.white.opacity(0.2), .white.opacity(0.2)], startPoint: .leading, endPoint: .trailing),
+                                lineWidth: 1
+                            )
+                    )
+                }
+                .buttonStyle(PlainButtonStyle())
+                .disabled(isAIProcessing)
+            }
+        }
+        .padding(.horizontal, DesignSystem.Spacing.xl)
+    }
+
+    private var micButton: some View {
+        ZStack {
+            // 펄스 링 (녹음 중 + 일시정지 아님)
+            if speechManager.isRecording && !speechManager.isPaused {
+                Circle()
+                    .fill(DesignSystem.Colors.primary.opacity(0.25))
+                    .frame(width: 160, height: 160)
+                    .scaleEffect(pulseAnimation ? 1.25 : 1.0)
+                    .opacity(pulseAnimation ? 0 : 0.5)
+                    .animation(.easeInOut(duration: 1.0).repeatForever(autoreverses: false), value: pulseAnimation)
+
+                Circle()
+                    .fill(DesignSystem.Colors.primary.opacity(0.15))
+                    .frame(width: 145, height: 145)
+                    .scaleEffect(pulseAnimation ? 1.3 : 1.0)
+                    .opacity(pulseAnimation ? 0 : 0.3)
+                    .animation(.easeInOut(duration: 1.0).repeatForever(autoreverses: false).delay(0.35), value: pulseAnimation)
+            }
+
+            if isAIProcessing {
+                Circle()
+                    .fill(LinearGradient(colors: [.purple.opacity(0.3), .blue.opacity(0.3), .cyan.opacity(0.3)], startPoint: .topLeading, endPoint: .bottomTrailing))
+                    .frame(width: 160, height: 160)
+                    .scaleEffect(pulseAnimation ? 1.2 : 1.0)
+                    .opacity(pulseAnimation ? 0 : 0.5)
+                    .animation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true), value: pulseAnimation)
+            }
+
+            Button(action: {
+                if !isAIProcessing { speechManager.toggleRecording() }
+            }) {
+                Circle()
+                    .fill(
+                        isAIProcessing
+                            ? LinearGradient(colors: [.purple, .blue, .cyan], startPoint: .topLeading, endPoint: .bottomTrailing)
+                            : speechManager.isPaused
+                                ? LinearGradient(colors: [.orange, .orange], startPoint: .topLeading, endPoint: .bottomTrailing)
+                                : speechManager.isRecording
+                                    ? LinearGradient(colors: [.red, .red], startPoint: .topLeading, endPoint: .bottomTrailing)
+                                    : LinearGradient(colors: [DesignSystem.Colors.primary, DesignSystem.Colors.primary], startPoint: .topLeading, endPoint: .bottomTrailing)
+                    )
+                    .frame(width: 120, height: 120)
+                    .shadow(
+                        color: (speechManager.isPaused ? Color.orange : speechManager.isRecording ? Color.red : DesignSystem.Colors.primary).opacity(0.4),
+                        radius: 20, x: 0, y: 10
+                    )
+                    .overlay(
+                        Group {
+                            if isAIProcessing {
+                                ProgressView().progressViewStyle(CircularProgressViewStyle(tint: .white)).scaleEffect(2)
+                            } else {
+                                Image(systemName: speechManager.isRecording ? "stop.fill" : "mic.fill")
+                                    .font(.system(size: 50, weight: .medium))
+                                    .foregroundColor(.white)
+                            }
+                        }
+                    )
+            }
+            .buttonStyle(PlainButtonStyle())
+            .disabled(isAIProcessing)
+        }
+    }
+
+    /// 실시간 파형 바 (7개)
+    private var waveformView: some View {
+        HStack(spacing: 5) {
+            ForEach(0..<7, id: \.self) { i in
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(
+                        speechManager.isPaused
+                            ? Color.orange.opacity(0.6)
+                            : speechManager.isRecording
+                                ? DesignSystem.Colors.primary.opacity(0.85)
+                                : Color.white.opacity(0.3)
+                    )
+                    .frame(width: 5, height: CGFloat(max(8, waveformLevels[i] * 48)))
+                    .animation(.easeOut(duration: 0.1), value: waveformLevels[i])
+            }
+        }
+        .frame(height: 52)
+    }
+
+    private var statusLabel: some View {
+        VStack(spacing: DesignSystem.Spacing.sm) {
+            if isAIProcessing {
+                Text(L.AI.summarizing)
+                    .font(DesignSystem.Typography.headline)
+                    .foregroundStyle(LinearGradient(colors: [.purple, .blue, .cyan], startPoint: .leading, endPoint: .trailing))
+            } else if speechManager.isPaused {
+                Text(L.VoiceEnhanced.paused)
+                    .font(DesignSystem.Typography.headline)
+                    .foregroundColor(.orange)
+            } else {
+                Text(speechManager.isRecording ? L.Voice.listening : L.Voice.tapToStart)
+                    .font(DesignSystem.Typography.headline)
+                    .foregroundColor(.white)
+            }
+
+            if let err = speechManager.errorMessage ?? aiErrorMessage {
+                Text(err)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundColor(.red.opacity(0.9))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, DesignSystem.Spacing.xl)
+            }
+        }
+    }
+
+    private var recognizedTextBox: some View {
+        ScrollView {
+            Text(speechManager.recognizedText)
+                .font(DesignSystem.Typography.body)
+                .foregroundColor(.white)
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(DesignSystem.Spacing.lg)
+        }
+        .frame(maxHeight: 160)
+        .background(Color.black.opacity(0.45))
+        .cornerRadius(DesignSystem.CornerRadius.medium)
+        .padding(.horizontal, DesignSystem.Spacing.xl)
+    }
+
+    private var bottomControls: some View {
+        VStack(spacing: DesignSystem.Spacing.md) {
+            // 타이머 (녹음 중일 때만)
+            if speechManager.isRecording {
+                Text(timerString)
+                    .font(.system(size: 22, weight: .semibold, design: .monospaced))
+                    .foregroundColor(speechManager.isPaused ? .orange : .white)
+                    .padding(.bottom, DesignSystem.Spacing.xs)
+            }
+
+            // 녹음 중: 일시정지 + 중지
+            if speechManager.isRecording {
+                HStack(spacing: DesignSystem.Spacing.lg) {
+                    // 일시정지 / 재개
+                    Button(action: { speechManager.togglePause() }) {
+                        HStack(spacing: DesignSystem.Spacing.sm) {
+                            Image(systemName: speechManager.isPaused ? "play.fill" : "pause.fill")
+                            Text(speechManager.isPaused ? L.VoiceEnhanced.resume : L.VoiceEnhanced.pause)
+                        }
+                        .font(DesignSystem.Typography.callout)
+                        .fontWeight(.medium)
+                        .foregroundColor(speechManager.isPaused ? .orange : .white)
+                        .padding(.horizontal, DesignSystem.Spacing.xl)
+                        .padding(.vertical, DesignSystem.Spacing.md)
+                        .background(speechManager.isPaused ? Color.orange.opacity(0.25) : Color.white.opacity(0.2))
+                        .cornerRadius(DesignSystem.CornerRadius.large)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+
+                    // 중지
+                    Button(action: { speechManager.stopRecording() }) {
+                        HStack(spacing: DesignSystem.Spacing.sm) {
+                            Image(systemName: "stop.circle.fill")
+                            Text(L.Voice.stopRecording)
+                        }
+                        .font(DesignSystem.Typography.callout)
+                        .fontWeight(.medium)
+                        .foregroundColor(.red)
+                        .padding(.horizontal, DesignSystem.Spacing.xl)
+                        .padding(.vertical, DesignSystem.Spacing.md)
+                        .background(Color.red.opacity(0.2))
+                        .cornerRadius(DesignSystem.CornerRadius.large)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                }
+            }
+
+            // AI 정리 버튼 (녹음 완료 + 텍스트 있음)
+            if !speechManager.recognizedText.isEmpty && !speechManager.isRecording && isAIAvailable {
+                Button(action: { performAISummarization() }) {
+                    HStack(spacing: DesignSystem.Spacing.sm) {
+                        Image(systemName: "sparkles")
+                        Text(L.AI.summarize)
+                    }
+                    .font(DesignSystem.Typography.headline)
+                    .foregroundStyle(LinearGradient(colors: [.purple, .blue, .cyan], startPoint: .leading, endPoint: .trailing))
+                    .padding(.horizontal, DesignSystem.Spacing.xl)
+                    .padding(.vertical, DesignSystem.Spacing.md)
+                    .background(LinearGradient(colors: [.purple.opacity(0.2), .blue.opacity(0.2), .cyan.opacity(0.2)], startPoint: .leading, endPoint: .trailing))
+                    .cornerRadius(DesignSystem.CornerRadius.large)
+                    .overlay(RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.large).stroke(LinearGradient(colors: [.purple.opacity(0.5), .cyan.opacity(0.5)], startPoint: .leading, endPoint: .trailing), lineWidth: 1))
+                }
+                .buttonStyle(PlainButtonStyle())
+                .disabled(isAIProcessing)
+            }
+
+            // 취소 / 사용 버튼
+            HStack(spacing: DesignSystem.Spacing.xl) {
+                Button(action: {
+                    speechManager.stopRecording()
+                    speechManager.clearText()
+                    onCancel()
+                }) {
+                    HStack(spacing: DesignSystem.Spacing.sm) {
+                        Image(systemName: "xmark")
+                        Text(L.Voice.cancel)
+                    }
+                    .font(DesignSystem.Typography.headline)
+                    .foregroundColor(.white.opacity(0.8))
+                    .padding(.horizontal, DesignSystem.Spacing.xl)
+                    .padding(.vertical, DesignSystem.Spacing.md)
+                    .background(Color.white.opacity(0.2))
+                    .cornerRadius(DesignSystem.CornerRadius.large)
+                }
+                .buttonStyle(PlainButtonStyle())
+                .disabled(isAIProcessing)
+
+                if !speechManager.recognizedText.isEmpty && !speechManager.isRecording {
+                    Button(action: {
+                        onUseText(speechManager.recognizedText)
+                        speechManager.clearText()
+                    }) {
+                        HStack(spacing: DesignSystem.Spacing.sm) {
+                            Image(systemName: "checkmark")
+                            Text(L.Voice.useText)
+                        }
+                        .font(DesignSystem.Typography.headline)
+                        .foregroundColor(.white)
+                        .padding(.horizontal, DesignSystem.Spacing.xl)
+                        .padding(.vertical, DesignSystem.Spacing.md)
+                        .background(DesignSystem.Colors.primary)
+                        .cornerRadius(DesignSystem.CornerRadius.large)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    .disabled(isAIProcessing)
+                }
+            }
+        }
+        .padding(.horizontal, DesignSystem.Spacing.xl)
+    }
+
+    // MARK: - Waveform Update
+
+    private func updateWaveform(level: Float) {
+        guard speechManager.isRecording && !speechManager.isPaused else {
+            // 정지/일시정지 시 잔잔하게
+            waveformLevels = waveformLevels.map { $0 * 0.7 }
+            return
+        }
+        // 레벨 기반 랜덤 파형 (자연스러운 느낌)
+        waveformLevels = waveformLevels.enumerated().map { i, prev in
+            let noise = Float.random(in: -0.15...0.15)
+            let target = max(0.1, min(1.0, level + noise))
+            // 이전 값과 부드럽게 보간
+            return prev * 0.4 + target * 0.6
+        }
+    }
+
     // MARK: - AI Summarization
 
     private func performAISummarization() {
         guard !speechManager.recognizedText.isEmpty else { return }
-
         isAIProcessing = true
         aiErrorMessage = nil
-
         Task {
             do {
                 if #available(iOS 26.0, *) {

--- a/PrayAnswer/ko.lproj/Localizable.strings
+++ b/PrayAnswer/ko.lproj/Localizable.strings
@@ -410,6 +410,54 @@
 "attachment.error_invalid_document" = "유효하지 않은 문서입니다";
 "attachment.error_unsupported_format" = "지원하지 않는 파일 형식입니다";
 
+// MARK: - Settings Tab
+"settings.tab_title" = "설정";
+"settings.guide_section" = "사용법 가이드";
+"settings.ai_section" = "AI · 음성 설정";
+"settings.ai_toggle" = "AI 요약 사용";
+"settings.ai_toggle_desc" = "음성 녹음 후 Apple Intelligence로 기도문을 자동 정리합니다 (iOS 18.1+, Apple Intelligence 필요)";
+"settings.bluetooth_tip" = "에어팟·블루투스 마이크를 연결하면 더 선명하게 녹음됩니다";
+"settings.voice_chunking_tip" = "긴 기도 나눔도 자동으로 이어 녹음됩니다 (1분 이상 지원)";
+"settings.stats_section" = "기도 통계";
+"settings.stats_button" = "기도 통계 보기";
+"settings.stats_desc" = "응답률, 카테고리 분포, 월별 기도 추이를 확인하세요";
+"settings.app_section" = "앱 정보";
+"settings.version" = "버전";
+"settings.contact" = "문의하기";
+"settings.review" = "앱 평가하기";
+"settings.privacy_policy" = "개인정보 처리방침";
+
+// MARK: - Feature Guide Cards
+"guide.add_prayer_title" = "기도제목 추가";
+"guide.add_prayer_desc" = "하단 '추가' 탭에서 기도제목·내용·카테고리·대상자를 입력하고 저장하세요.";
+"guide.storage_title" = "보관소 관리";
+"guide.storage_desc" = "Wait·Yes·No 세 보관소로 기도 상태를 추적하세요. 상세 화면에서 보관소를 이동할 수 있습니다.";
+"guide.people_title" = "여러 사람 기도";
+"guide.people_desc" = "'대상자' 탭에서 사람별 기도제목을 한눈에 관리하세요. 가족·친구·공동체별로 정리됩니다.";
+"guide.favorite_title" = "즐겨찾기";
+"guide.favorite_desc" = "자주 기도하는 제목에 ♥를 표시하면 위젯과 목록 상단에서 빠르게 접근할 수 있습니다.";
+"guide.habit_title" = "기도 습관";
+"guide.habit_desc" = "'습관' 탭에서 매일 기도 체크인을 기록하세요. 연속 기도일과 주간 달력으로 꾸준함을 확인할 수 있습니다.";
+"guide.widget_title" = "홈 화면 위젯";
+"guide.widget_desc" = "홈 화면 길게 누르기 → 위젯 추가 → PrayAnswer. 기도제목 확인과 빠른 추가가 잠금 화면에서도 가능합니다.";
+"guide.exchange_title" = "기도 교환";
+"guide.exchange_desc" = "기도제목을 상대방과 교환하세요. 앱이 있으면 딥링크로 바로 저장, 없으면 텍스트로 전달됩니다.";
+"guide.share_ext_title" = "다른 앱에서 가져오기";
+"guide.share_ext_desc" = "카카오톡·메모 등에서 텍스트를 선택 → 공유 → PrayAnswer를 탭하면 바로 기도제목으로 추가됩니다.";
+"guide.collection_title" = "컬렉션(폴더)";
+"guide.collection_desc" = "기도제목을 주제별 폴더로 묶어 정리하세요. 기도제목 추가·편집 화면에서 폴더를 지정할 수 있습니다.";
+"guide.answer_note_title" = "응답 기록";
+"guide.answer_note_desc" = "기도가 응답받으면 Yes로 이동할 때 어떻게 응답받았는지 메모를 남겨 하나님의 역사를 기록하세요.";
+"guide.voice_ai_title" = "음성 AI 기록";
+"guide.voice_ai_desc" = "기도제목 추가·편집 화면의 🎤 버튼으로 말하면 Apple Intelligence가 기도문으로 자동 정리해 줍니다.";
+
+// MARK: - Voice Enhanced
+"voice.pause" = "일시정지";
+"voice.resume" = "재개";
+"voice.paused" = "일시정지됨";
+"voice.continuing" = "계속 녹음 중...";
+"voice.timer_format" = "%02d:%02d";
+
 // MARK: - Answer Note (응답/거절 메모)
 "answer_note.section_title" = "응답 기록";
 "answer_note.placeholder" = "어떻게 응답받으셨나요? (선택 입력)";


### PR DESCRIPTION
## 개요
이전 PR(#4) 머지 이후 추가된 작업입니다. 설정 탭 신설 및 외부 연결 정비, 음성 녹음 강화, 사용법 가이드 분리, 배너 애니메이션 수정을 포함합니다.

## 주요 변경

### ⚙️ 설정 화면
- **설정 탭 신설** + 음성 녹음 강화 (v2)
- 외부 연결 정비
  - 문의하기: 이메일 → Instagram(@mordecai_kwan)
  - 개인정보 처리방침: Notion 페이지로 교체
  - 앱 평가: StoreKit 인앱 시트 → App Store 리뷰 작성 페이지 직접 연결
- **사용법 가이드**: 길게 나열되던 항목을 NavigationLink 한 줄로 축소하고 별도 화면(`FeatureGuideView`)으로 분리

### 🔗 App Store 링크
- placeholder였던 App Store ID(`6748534851`)를 실제 라이브 ID(`6748029078`)로 교체
  - 평가하기 버튼 + 기도 교환 공유 메시지 링크 동시 정상화 (KR·US 스토어프론트 확인)
- 기도 교환 공유 메시지 문구를 실제 전달 방식(파일 기반 + App Store 안내)에 맞게 수정

### 🎨 UI
- 나의 기도제목 배너 펼침/접힘 애니메이션 방향 정리 (펼침=아래로, 접힘=위로)

## 테스트
- `xcodebuild` (iPhone 17 시뮬레이터, iOS 26.5) **BUILD SUCCEEDED**
- ⚠️ 평가하기 버튼은 시뮬레이터에서 App Store 미동작 → **실기기 확인 필요**

🤖 Generated with [Claude Code](https://claude.com/claude-code)