### PR TITLE
fix: 음성 녹음 시작 실패 회귀 수정

### DIFF
--- a/PrayAnswer/Utils/SpeechRecognitionManager.swift
+++ b/PrayAnswer/Utils/SpeechRecognitionManager.swift
@@ -202,11 +202,13 @@ final class SpeechRecognitionManager: NSObject {
         }
 
         let audioSession = AVAudioSession.sharedInstance()
-        // 블루투스/에어팟 마이크 지원 + 음성 최적화 모드
+        // 블루투스/에어팟 마이크(HFP) 지원 + 음성 최적화 모드 + 타 오디오 일시 감쇠.
+        // 주의: .allowBluetoothA2DP는 .playAndRecord 카테고리에서만 유효하고
+        //      A2DP는 출력 전용이라 녹음엔 무용 → 사용하지 않음.
         try audioSession.setCategory(
             .record,
-            mode: .default,
-            options: [.allowBluetooth, .allowBluetoothA2DP]
+            mode: .measurement,
+            options: [.allowBluetooth, .duckOthers]
         )
         try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
 


### PR DESCRIPTION
## 개요
PR #5 머지 이후 발견된 음성 녹음 회귀를 수정합니다.

## 문제
직전 "음성 녹음 강화"(`fa0a61c`)에서 AVAudioSession에 다음 옵션 조합을 적용:
```swift
.setCategory(.record, mode: .default, options: [.allowBluetooth, .allowBluetoothA2DP])
```
`.allowBluetoothA2DP`는 Apple 공식상 **`.playAndRecord` 카테고리에서만 유효**하고, A2DP 자체가 출력 전용 프로토콜이라 마이크 녹음엔 무용. `.record`와 조합하면 `setCategory`가 throw → `startRecognitionSession()` 실패 → 녹음 시작 자체가 안 되는 회귀 발생.

## 수정
```swift
.setCategory(.record, mode: .measurement, options: [.allowBluetooth, .duckOthers])
```
- 잘못된 `.allowBluetoothA2DP` 제거 (BT 마이크는 HFP만으로 충분)
- 직전 정상 동작 시점의 `.measurement` 모드와 `.duckOthers` 복구
- AirPods/BT 마이크 지원(`.allowBluetooth`)은 그대로 유지

## 테스트
- `xcodebuild` (iPhone 17 시뮬레이터, iOS 26.5) **BUILD SUCCEEDED**
- 사용자 실기기 검증 완료 — 녹음 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)