### PR TITLE
chore: Claude Code 허용 명령어 목록 확장

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -125,7 +125,17 @@
       "Bash(wc -l \"/Users/bear/Library/Mobile Documents/com~apple~CloudDocs/AppleAcademy/Xcode/PrayAnswer/PrayAnswer/Views\"/*.swift)",
       "Bash(wc -l \"/Users/bear/Library/Mobile Documents/com~apple~CloudDocs/AppleAcademy/Xcode/PrayAnswer/PrayAnswer/Views/Components\"/*.swift)",
       "Bash(wc -l \"/Users/bear/Library/Mobile Documents/com~apple~CloudDocs/AppleAcademy/Xcode/PrayAnswer/PrayAnswer/Models\"/*.swift)",
-      "Bash(wc -l \"/Users/bear/Library/Mobile Documents/com~apple~CloudDocs/AppleAcademy/Xcode/PrayAnswer/PrayAnswer/Utils\"/*.swift)"
+      "Bash(wc -l \"/Users/bear/Library/Mobile Documents/com~apple~CloudDocs/AppleAcademy/Xcode/PrayAnswer/PrayAnswer/Utils\"/*.swift)",
+      "Bash(gh pr create --title 'feat: 나의 기도 교환 기능 추가 및 UI 전반 개선' --body ' *)",
+      "Bash(git log *)",
+      "Bash(grep -rniE \"requestReview|SKStoreReview|StoreReviewController|reviewCount|requestReviewIfAppropriate|prayerCount.*review|review.*prayerCount\" PrayAnswer PrayerWidget PrayAnswerShareExtension --include=\"*.swift\")",
+      "Bash(grep -rn \"import StoreKit\" PrayAnswer PrayerWidget PrayAnswerShareExtension --include=\"*.swift\")",
+      "WebFetch(domain:apps.apple.com)",
+      "WebFetch(domain:itunes.apple.com)",
+      "Bash(gh pr *)",
+      "Bash(gh repo *)",
+      "Bash(git fetch *)",
+      "Bash(git branch *)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- `gh pr *`, `gh repo *`, `git fetch *`, `git branch *` 등 자주 사용하는 명령어 허용 목록 추가
- `grep` 패턴 명령어 추가로 코드 탐색 시 권한 프롬프트 감소
- `WebFetch` App Store 도메인 접근 허용

## Test plan
- [ ] Claude Code 실행 후 해당 명령어들이 자동 허용되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)